### PR TITLE
fix: async close

### DIFF
--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -46,11 +46,15 @@
 #include <mcap/mcap.hpp>
 
 #include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
 #include <filesystem>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -165,6 +169,100 @@ static void OnProblem(const mcap::Status & status)
   RCUTILS_LOG_ERROR_NAMED(LOG_NAME, "%s", status.message.c_str());
 }
 
+namespace
+{
+
+/// Closes MCAP writers on a background thread so rollover can open the next file without
+/// blocking on summary/footer I/O for the previous file.
+class McapWriterAsyncCloser
+{
+public:
+  McapWriterAsyncCloser()
+  {
+    worker_ = std::thread([this]() {  worker_loop(); });
+  }
+
+  ~McapWriterAsyncCloser() { shutdown(); }
+
+  McapWriterAsyncCloser(const McapWriterAsyncCloser &) = delete;
+  McapWriterAsyncCloser & operator=(const McapWriterAsyncCloser &) = delete;
+
+  void enqueue(std::unique_ptr<mcap::McapWriter> writer, std::string relative_path)
+  {
+    if (!writer) {
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      queue_.push_back({std::move(writer), std::move(relative_path)});
+    }
+    cv_.notify_one();
+  }
+
+  void shutdown()
+  {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (shutdown_) {
+        return;
+      }
+      shutdown_ = true;
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) {
+      worker_.join();
+    }
+  }
+
+private:
+  struct CloseJob
+  {
+    std::unique_ptr<mcap::McapWriter> writer;
+    std::string relative_path;
+  };
+
+  void worker_loop()
+  {
+    while (true) {
+      CloseJob job;
+      {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this]() { return shutdown_ || !queue_.empty(); });
+        if (shutdown_ && queue_.empty()) {
+          return;
+        }
+        job = std::move(queue_.front());
+        queue_.pop_front();
+      }
+
+      if (job.writer) {
+        const auto close_start = std::chrono::steady_clock::now();
+        try {
+          job.writer->close();
+        } catch (const std::exception & e) {
+          RCUTILS_LOG_ERROR_NAMED(
+            LOG_NAME, "Async MCAP close failed for \"%s\": %s", job.relative_path.c_str(),
+            e.what());
+        }
+        const double close_ms =
+          std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - close_start)
+            .count();
+        RCUTILS_LOG_INFO_NAMED(
+          LOG_NAME, "MCAP async close timing (ms): close=%.3f, file=\"%s\"", close_ms,
+          job.relative_path.c_str());
+      }
+    }
+  }
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::deque<CloseJob> queue_;
+  std::thread worker_;
+  bool shutdown_{false};
+};
+
+}  // namespace
+
 /**
  * A storage implementation for the MCAP file format.
  */
@@ -271,6 +369,8 @@ private:
   std::unordered_map<std::string, mcap::Channel> cached_mcap_channels_
     RCPPUTILS_TSA_GUARDED_BY(mcap_storage_mutex_);
 
+  std::unique_ptr<McapWriterAsyncCloser> async_writer_closer_;
+
   bool has_read_summary_ = false;
   bool has_added_ros_distro_metadata_ = false;
   rcutils_time_point_value_t last_read_time_point_ = 0;
@@ -291,6 +391,11 @@ MCAPStorage::~MCAPStorage()
   }
   if (input_) {
     input_->close();
+  }
+  // Wait for any rollover-triggered async closes before closing the active writer.
+  if (async_writer_closer_) {
+    async_writer_closer_->shutdown();
+    async_writer_closer_.reset();
   }
   if (mcap_writer_) {
     mcap_writer_->close();
@@ -379,6 +484,9 @@ void MCAPStorage::open_impl(const std::string & uri, const std::string & preset_
       }
       writer_options_ = options;
       writer_options_initialized_ = true;
+      if (!async_writer_closer_) {
+        async_writer_closer_ = std::make_unique<McapWriterAsyncCloser>();
+      }
       ensure_rosdistro_metadata_added();
       break;
     }
@@ -820,15 +928,25 @@ void MCAPStorage::remove_topic(const rosbag2_storage::TopicMetadata & topic)
 
 void MCAPStorage::register_cached_topics()
 {
+  using clock = std::chrono::steady_clock;
+  const auto register_start = clock::now();
+  auto to_ms = [](const auto & duration) {
+    return std::chrono::duration<double, std::milli>(duration).count();
+  };
+
   schema_ids_.clear();
   channel_ids_.clear();
 
+  const auto add_schemas_start = clock::now();
   for (const auto & [datatype, schema_template] : cached_mcap_schemas_) {
     mcap::Schema schema = schema_template;
     mcap_writer_->addSchema(schema);
     schema_ids_.emplace(datatype, schema.id);
   }
+  const double add_schemas_ms = to_ms(clock::now() - add_schemas_start);
 
+  const auto add_channels_start = clock::now();
+  size_t channels_registered = 0;
   for (const auto & [topic_name, channel_template] : cached_mcap_channels_) {
     const auto topic_it = topics_.find(topic_name);
     if (topic_it == topics_.end()) {
@@ -839,7 +957,16 @@ void MCAPStorage::register_cached_topics()
     channel.schemaId = schema_ids_.at(datatype);
     mcap_writer_->addChannel(channel);
     channel_ids_.emplace(topic_name, channel.id);
+    ++channels_registered;
   }
+  const double add_channels_ms = to_ms(clock::now() - add_channels_start);
+
+  RCUTILS_LOG_INFO_NAMED(
+    LOG_NAME,
+    "MCAP register_cached_topics timing (ms): total=%.3f, add_schemas=%.3f (%zu schemas), "
+    "add_channels=%.3f (%zu channels)",
+    to_ms(clock::now() - register_start), add_schemas_ms, cached_mcap_schemas_.size(),
+    add_channels_ms, channels_registered);
 }
 
 bool MCAPStorage::rollover(const rosbag2_storage::StorageOptions & storage_options)
@@ -848,26 +975,63 @@ bool MCAPStorage::rollover(const rosbag2_storage::StorageOptions & storage_optio
     return false;
   }
 
-  std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
-  mcap_writer_->close();
+  using clock = std::chrono::steady_clock;
+  const auto rollover_start = clock::now();
+  auto to_ms = [](const auto & duration) {
+    return std::chrono::duration<double, std::milli>(duration).count();
+  };
 
-  relative_path_ = storage_options.uri + FILE_EXTENSION;
-  mcap_writer_ = std::make_unique<mcap::McapWriter>();
-  auto status = mcap_writer_->open(relative_path_, writer_options_);
-  if (!status.ok()) {
-    throw std::runtime_error(status.message);
+  std::unique_ptr<mcap::McapWriter> old_writer;
+  std::string closing_relative_path;
+
+  {
+    std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
+
+    old_writer = std::move(mcap_writer_);
+    closing_relative_path = relative_path_;
+
+    relative_path_ = storage_options.uri + FILE_EXTENSION;
+
+    const auto open_start = clock::now();
+    mcap_writer_ = std::make_unique<mcap::McapWriter>();
+    auto status = mcap_writer_->open(relative_path_, writer_options_);
+    const double open_ms = to_ms(clock::now() - open_start);
+    if (!status.ok()) {
+      mcap_writer_.reset();
+      mcap_writer_ = std::move(old_writer);
+      relative_path_ = closing_relative_path;
+      throw std::runtime_error(status.message);
+    }
+
+    const auto reset_metadata_start = clock::now();
+    for (auto & [topic_name, topic_info] : topics_) {
+      (void)topic_name;
+      topic_info.message_count = 0;
+    }
+    metadata_.message_count = 0;
+    metadata_.duration = std::chrono::nanoseconds(0);
+    metadata_.starting_time = time_point(std::chrono::nanoseconds::max());
+    metadata_.relative_file_paths = {get_relative_file_path()};
+    const double reset_metadata_ms = to_ms(clock::now() - reset_metadata_start);
+
+    const auto register_topics_start = clock::now();
+    register_cached_topics();
+    const double register_topics_ms = to_ms(clock::now() - register_topics_start);
+
+    const double sync_rollover_ms = to_ms(clock::now() - rollover_start);
+    RCUTILS_LOG_INFO_NAMED(
+      LOG_NAME,
+      "MCAP rollover timing (ms): sync_total=%.3f, close=async_scheduled, open=%.3f, "
+      "reset_metadata=%.3f, register_cached_topics=%.3f, closing_file=\"%s\", new_file=\"%s\"",
+      sync_rollover_ms, open_ms, reset_metadata_ms, register_topics_ms,
+      closing_relative_path.c_str(), relative_path_.c_str());
   }
 
-  for (auto & [topic_name, topic_info] : topics_) {
-    (void)topic_name;
-    topic_info.message_count = 0;
+  if (!async_writer_closer_) {
+    async_writer_closer_ = std::make_unique<McapWriterAsyncCloser>();
   }
-  metadata_.message_count = 0;
-  metadata_.duration = std::chrono::nanoseconds(0);
-  metadata_.starting_time = time_point(std::chrono::nanoseconds::max());
-  metadata_.relative_file_paths = {get_relative_file_path()};
+  async_writer_closer_->enqueue(std::move(old_writer), std::move(closing_relative_path));
 
-  register_cached_topics();
   return true;
 }
 


### PR DESCRIPTION
@KYabuuchi 

The problem I saw in the  previous updates on my own PC:

```
[INFO] [1782089866.972994269] [rosbag2_storage_mcap]: MCAP rollover timing (ms): total=6.772, close=6.140, open=0.088, reset_metadata=0.034, register_cached_topics=0.509, new_file="my_full_bag/my_full_bag_3.mcap"
[INFO] [1782089866.973029499] [rosbag2_cpp]: Bag split storage switch timing (ms): total=6.88556, cache_flush=0.073623, rollover=6.77791, cache_restart=0.025562, new_file="my_full_bag/my_full_bag_3"
[INFO] [1782089876.971202330] [rosbag2_cpp]: Writing remaining messages from cache to the bag. It may take a while
[INFO] [1782089876.971267336] [rosbag2_cpp]: Cache consumer stop timing (ms): total=0.067979, consumer_join=0.027052
[INFO] [1782089876.978535232] [rosbag2_storage_mcap]: MCAP register_cached_topics timing (ms): total=0.603, add_schemas=0.178 (142 schemas), add_channels=0.409 (350 channels)
[INFO] [1782089876.978558398] [rosbag2_storage_mcap]: MCAP rollover timing (ms): total=7.276, close=6.520, open=0.096, reset_metadata=0.032, register_cached_topics=0.626, new_file="my_full_bag/my_full_bag_4.mcap"
[INFO] [1782089876.978604822] [rosbag2_cpp]: Bag split storage switch timing (ms): total=7.4067, cache_flush=0.081274, rollover=7.28484, cache_restart=0.031794, new_file="my_full_bag/my_full_bag_4"
[INFO] [1782089886.971250629] [rosbag2_cpp]: Writing remaining messages from cache to the bag. It may take a while
[INFO] [1782089886.971402441] [rosbag2_cpp]: Cache consumer stop timing (ms): total=0.157702, consumer_join=0.111259
[INFO] [1782089886.976616431] [rosbag2_storage_mcap]: MCAP register_cached_topics timing (ms): total=0.429, add_schemas=0.126 (142 schemas), add_channels=0.292 (350 channels)
[INFO] [1782089886.976634984] [rosbag2_storage_mcap]: MCAP rollover timing (ms): total=5.220, close=4.659, open=0.076, reset_metadata=0.036, register_cached_topics=0.448, new_file="my_full_bag/my_full_bag_5.mcap"
[INFO] [1782089886.976661444] [rosbag2_cpp]: Bag split storage switch timing (ms): total=5.41785, cache_flush=0.167824, rollover=5.22638, cache_restart=0.015951, new_file="my_full_bag/my_full_bag_5"
[INFO] [1782089896.971302478] [rosbag2_cpp]: Writing remaining messages from cache to the bag. It may take a while
[INFO] [1782089896.971414326] [rosbag2_cpp]: Cache consumer stop timing (ms): total=0.111349, consumer_join=0.082493
[INFO] [1782089896.976667349] [rosbag2_storage_mcap]: MCAP register_cached_topics timing (ms): total=0.420, add_schemas=0.116 (142 schemas), add_channels=0.287 (350 channels)
[INFO] [1782089896.976683415] [rosbag2_storage_mcap]: MCAP rollover timing (ms): total=5.260, close=4.723, open=0.070, reset_metadata=0.030, register_cached_topics=0.437, new_file="my_full_bag/my_full_bag_6.mcap"
[INFO] [1782089896.976716504] [rosbag2_cpp]: Bag split storage switch timing (ms): total=5.41476, cache_flush=0.119102, rollover=5.26565, cache_restart=0.02391, new_file="my_full_bag/my_full_bag_6"
[INFO] [1782089897.824429833] [rosbag2_cpp]: Writing remaining messages from cache to the bag. It may take a while
[INFO] [1782089897.824483368] [rosbag2_cpp]: Cache consumer stop timing (ms): total=0.055971, consumer_join=0.015547
[INFO] [1782089897.844382017] [rosbag2_recorder]: Event publisher thread: Exiting
[INFO] [1782089897.844452368] [rosbag2_recorder]: Recording stopped
```

It turns out that "closing" old bag is costing 5ms on desktop PC, maybe this results in 50ms delay on the logging ECU (it include writing to the file system too).


So the basic idea is to close the old completed bag with an async function(because it does not affect the system). Also additional timing log is added so everyone can debug easier.