### PR TITLE
feat: cursor fix

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/cache/cache_consumer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/cache_consumer.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 
 #include "rosbag2_cpp/cache/cache_consumer.hpp"
@@ -38,16 +39,29 @@ CacheConsumer::~CacheConsumer()
 
 void CacheConsumer::stop()
 {
+  using clock = std::chrono::steady_clock;
+  const auto stop_start = clock::now();
+
   message_cache_->begin_flushing();
   is_stop_issued_ = true;
 
   ROSBAG2_CPP_LOG_INFO_STREAM(
     "Writing remaining messages from cache to the bag. It may take a while");
 
+  double consumer_join_ms = 0.0;
   if (consumer_thread_.joinable()) {
+    const auto join_start = clock::now();
     consumer_thread_.join();
+    consumer_join_ms = std::chrono::duration<double, std::milli>(
+      clock::now() - join_start).count();
   }
   message_cache_->done_flushing();
+
+  const auto total_ms = std::chrono::duration<double, std::milli>(
+    clock::now() - stop_start).count();
+  ROSBAG2_CPP_LOG_INFO_STREAM(
+    "Cache consumer stop timing (ms): total=" << total_ms
+                                              << ", consumer_join=" << consumer_join_ms);
 }
 
 void CacheConsumer::start()

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -266,16 +266,34 @@ std::string SequentialWriter::format_storage_uri(
 
 void SequentialWriter::switch_to_next_storage()
 {
+  using clock = std::chrono::steady_clock;
+  const auto switch_start = clock::now();
+  auto to_ms = [](const auto & duration) {
+      return std::chrono::duration<double, std::milli>(duration).count();
+    };
+
+  double cache_flush_ms = 0.0;
+  double open_new_storage_ms = 0.0;
+  double close_old_storage_ms = 0.0;
+  double reregister_topics_ms = 0.0;
+  double cache_restart_ms = 0.0;
+
   // consume remaining message cache
   if (use_cache_) {
+    const auto cache_flush_start = clock::now();
     cache_consumer_->stop();
     message_cache_->log_dropped();
+    cache_flush_ms = to_ms(clock::now() - cache_flush_start);
   }
 
   storage_options_.uri = format_storage_uri(
     base_folder_,
     metadata_.relative_file_paths.size());
+
+  auto previous_storage = std::move(storage_);
+  const auto open_new_storage_start = clock::now();
   storage_ = storage_factory_->open_read_write(storage_options_);
+  open_new_storage_ms = to_ms(clock::now() - open_new_storage_start);
 
   if (!storage_) {
     std::stringstream errmsg;
@@ -284,15 +302,35 @@ void SequentialWriter::switch_to_next_storage()
     throw std::runtime_error(errmsg.str());
   }
 
+  const auto close_old_storage_start = clock::now();
+  previous_storage.reset();
+  close_old_storage_ms = to_ms(clock::now() - close_old_storage_start);
+
   // Re-register all topics since we rolled-over to a new bagfile.
+  const auto reregister_topics_start = clock::now();
   for (const auto & topic : topics_names_to_info_) {
     storage_->create_topic(topic.second.topic_metadata);
   }
+  reregister_topics_ms = to_ms(clock::now() - reregister_topics_start);
 
   if (use_cache_) {
+    const auto cache_restart_start = clock::now();
     // restart consumer thread for cache
     cache_consumer_->start();
+    cache_restart_ms = to_ms(clock::now() - cache_restart_start);
   }
+
+  const auto total_ms = to_ms(clock::now() - switch_start);
+  ROSBAG2_CPP_LOG_INFO_STREAM(
+    "Bag split storage switch timing (ms): "
+    << "total=" << total_ms
+    << ", cache_flush=" << cache_flush_ms
+    << ", open_new_storage=" << open_new_storage_ms
+    << ", close_old_storage=" << close_old_storage_ms
+    << ", reregister_topics=" << reregister_topics_ms
+    << " (" << topics_names_to_info_.size() << " topics)"
+    << ", cache_restart=" << cache_restart_ms
+    << ", new_file=\"" << storage_options_.uri << "\"");
 }
 
 std::string SequentialWriter::split_bagfile_local(bool execute_callbacks)

--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
@@ -15,18 +15,18 @@
 #ifndef ROSBAG2_STORAGE_MCAP__MESSAGE_DEFINITION_CACHE_HPP_
 #define ROSBAG2_STORAGE_MCAP__MESSAGE_DEFINITION_CACHE_HPP_
 
-#include "visibility_control.hpp"
-
+#include <mutex>
 #include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
+#include "visibility_control.hpp"
+
 namespace rosbag2_storage_mcap::internal
 {
-enum struct Format
-{
+enum struct Format {
   IDL,
   MSG,
   UNKNOWN,
@@ -57,15 +57,9 @@ private:
   std::string name_;
 
 public:
-  explicit DefinitionNotFoundError(std::string name)
-      : name_(std::move(name))
-  {
-  }
+  explicit DefinitionNotFoundError(std::string name) : name_(std::move(name)) {}
 
-  const char * what() const noexcept override
-  {
-    return name_.c_str();
-  }
+  const char * what() const noexcept override { return name_.c_str(); }
 };
 
 class MessageDefinitionCache final
@@ -98,13 +92,17 @@ private:
    */
   const MessageSpec & load_message_spec(const DefinitionIdentifier & definition_identifier);
 
+  std::pair<Format, std::string> get_full_text_unlocked(const std::string & package_resource_name);
+
   std::unordered_map<DefinitionIdentifier, MessageSpec, DefinitionIdentifierHash>
     msg_specs_by_definition_identifier_;
+  std::unordered_map<std::string, std::pair<Format, std::string>> full_text_by_datatype_;
+  std::mutex cache_mutex_;
 };
 
 ROSBAG2_STORAGE_MCAP_PUBLIC
-std::set<std::string> parse_dependencies(Format format, const std::string & text,
-                                         const std::string & package_context);
+std::set<std::string> parse_dependencies(
+  Format format, const std::string & text, const std::string & package_context);
 
 }  // namespace rosbag2_storage_mcap::internal
 

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -260,7 +260,8 @@ private:
   std::unique_ptr<mcap::LinearMessageView::Iterator> linear_iterator_;
 
   std::unique_ptr<mcap::McapWriter> mcap_writer_;
-  rosbag2_storage_mcap::internal::MessageDefinitionCache msgdef_cache_{};
+
+  static rosbag2_storage_mcap::internal::MessageDefinitionCache & msgdef_cache();
 
   bool has_read_summary_ = false;
   bool has_added_ros_distro_metadata_ = false;
@@ -268,6 +269,12 @@ private:
   std::optional<mcap::RecordOffset> last_read_message_offset_;
   std::optional<mcap::RecordOffset> last_enqueued_message_offset_;
 };
+
+rosbag2_storage_mcap::internal::MessageDefinitionCache & MCAPStorage::msgdef_cache()
+{
+  static rosbag2_storage_mcap::internal::MessageDefinitionCache cache;
+  return cache;
+}
 
 MCAPStorage::MCAPStorage()
 {
@@ -742,7 +749,7 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
     mcap::Schema schema;
     schema.name = datatype;
     try {
-      auto [format, full_text] = msgdef_cache_.get_full_text(datatype);
+      auto [format, full_text] = msgdef_cache().get_full_text(datatype);
       switch (format) {
         case rosbag2_storage_mcap::internal::Format::UNKNOWN:
           schema.encoding = "unknown";

--- a/rosbag2_storage_mcap/src/message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/src/message_definition_cache.cpp
@@ -14,12 +14,12 @@
 
 #include "rosbag2_storage_mcap/message_definition_cache.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <ament_index_cpp/get_package_prefix.hpp>
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <ament_index_cpp/get_resource.hpp>
 #include <ament_index_cpp/get_resources.hpp>
-#include <rcutils/logging_macros.h>
-
 #include <fstream>
 #include <functional>
 #include <optional>
@@ -40,15 +40,9 @@ private:
   std::string name_;
 
 public:
-  explicit TypenameNotUnderstoodError(std::string name)
-      : name_(std::move(name))
-  {
-  }
+  explicit TypenameNotUnderstoodError(std::string name) : name_(std::move(name)) {}
 
-  const char * what() const noexcept override
-  {
-    return name_.c_str();
-  }
+  const char * what() const noexcept override { return name_.c_str(); }
 };
 
 // Match datatype names (foo_msgs/Bar or foo_msgs/msg/Bar)
@@ -66,8 +60,8 @@ static const std::unordered_set<std::string> PRIMITIVE_TYPES{
   "bool",  "byte",   "char",  "float32", "float64", "int8",   "uint8",
   "int16", "uint16", "int32", "uint32",  "int64",   "uint64", "string"};
 
-static std::set<std::string> parse_msg_dependencies(const std::string & text,
-                                                    const std::string & package_context)
+static std::set<std::string> parse_msg_dependencies(
+  const std::string & text, const std::string & package_context)
 {
   std::set<std::string> dependencies;
 
@@ -97,8 +91,8 @@ static std::set<std::string> parse_idl_dependencies(const std::string & text)
   return dependencies;
 }
 
-std::set<std::string> parse_dependencies(Format format, const std::string & text,
-                                         const std::string & package_context)
+std::set<std::string> parse_dependencies(
+  Format format, const std::string & text, const std::string & package_context)
 {
   switch (format) {
     case Format::MSG:
@@ -142,9 +136,9 @@ static std::string delimiter(const DefinitionIdentifier & definition_identifier)
 }
 
 MessageSpec::MessageSpec(Format format, std::string text, const std::string & package_context)
-    : dependencies(parse_dependencies(format, text, package_context))
-    , text(std::move(text))
-    , format(format)
+: dependencies(parse_dependencies(format, text, package_context)),
+  text(std::move(text)),
+  format(format)
 {
 }
 
@@ -156,8 +150,8 @@ const MessageSpec & MessageDefinitionCache::load_message_spec(
     return it->second;
   }
   std::smatch match;
-  if (!std::regex_match(definition_identifier.package_resource_name, match,
-                        PACKAGE_TYPENAME_REGEX)) {
+  if (!std::regex_match(
+        definition_identifier.package_resource_name, match, PACKAGE_TYPENAME_REGEX)) {
     throw TypenameNotUnderstoodError(definition_identifier.package_resource_name);
   }
   const std::string package = match[1];
@@ -173,8 +167,9 @@ const MessageSpec & MessageDefinitionCache::load_message_spec(
     RCUTILS_LOG_WARN_NAMED("rosbag2_storage_mcap", "%s", e.what());
     throw DefinitionNotFoundError(definition_identifier.package_resource_name);
   }
-  std::ifstream file{share_dir + "/" + namespace_name + "/" + type_name +
-                     extension_for_format(definition_identifier.format)};
+  std::ifstream file{
+    share_dir + "/" + namespace_name + "/" + type_name +
+    extension_for_format(definition_identifier.format)};
   if (!file.good()) {
     throw DefinitionNotFoundError(definition_identifier.package_resource_name);
   }
@@ -182,8 +177,9 @@ const MessageSpec & MessageDefinitionCache::load_message_spec(
   std::string contents{std::istreambuf_iterator(file), {}};
   const MessageSpec & spec =
     msg_specs_by_definition_identifier_
-      .emplace(definition_identifier,
-               MessageSpec(definition_identifier.format, std::move(contents), package))
+      .emplace(
+        definition_identifier,
+        MessageSpec(definition_identifier.format, std::move(contents), package))
       .first->second;
 
   // "References and pointers to data stored in the container are only invalidated by erasing that
@@ -194,13 +190,26 @@ const MessageSpec & MessageDefinitionCache::load_message_spec(
 std::pair<Format, std::string> MessageDefinitionCache::get_full_text(
   const std::string & root_package_resource_name)
 {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  if (const auto cached = full_text_by_datatype_.find(root_package_resource_name);
+      cached != full_text_by_datatype_.end()) {
+    return cached->second;
+  }
+  auto result = get_full_text_unlocked(root_package_resource_name);
+  full_text_by_datatype_.emplace(root_package_resource_name, result);
+  return result;
+}
+
+std::pair<Format, std::string> MessageDefinitionCache::get_full_text_unlocked(
+  const std::string & root_package_resource_name)
+{
   std::unordered_set<DefinitionIdentifier, DefinitionIdentifierHash> seen_deps;
 
   std::function<std::string(const DefinitionIdentifier &, int32_t)> append_recursive =
     [&](const DefinitionIdentifier & definition_identifier, int32_t depth) {
       if (depth <= 0) {
-        throw std::runtime_error{"Reached max recursion depth resolving definition of " +
-                                 root_package_resource_name};
+        throw std::runtime_error{
+          "Reached max recursion depth resolving definition of " + root_package_resource_name};
       }
       const MessageSpec & spec = load_message_spec(definition_identifier);
       std::string result = spec.text;
@@ -221,28 +230,30 @@ std::pair<Format, std::string> MessageDefinitionCache::get_full_text(
   int32_t max_recursion_depth = MESSAGE_DEFINITION_SOURCE_MAX_RECURSION_DEPTH;
   try {
     try {
-      result = append_recursive(DefinitionIdentifier{format, root_package_resource_name},
-                                max_recursion_depth);
+      result = append_recursive(
+        DefinitionIdentifier{format, root_package_resource_name}, max_recursion_depth);
     } catch (const DefinitionNotFoundError & err) {
       // log that we've fallen back
-      RCUTILS_LOG_WARN_NAMED("rosbag2_storage_mcap",
-                             "no .msg definition for %s, falling back to IDL", err.what());
+      RCUTILS_LOG_WARN_NAMED(
+        "rosbag2_storage_mcap", "no .msg definition for %s, falling back to IDL", err.what());
       format = Format::IDL;
       DefinitionIdentifier root_definition_identifier{format, root_package_resource_name};
       result = delimiter(root_definition_identifier) +
                append_recursive(root_definition_identifier, max_recursion_depth);
     }
   } catch (const TypenameNotUnderstoodError & err) {
-    RCUTILS_LOG_ERROR_NAMED("rosbag2_storage_mcap",
-                            "Message type name '%s' is not understood by type definition search, "
-                            "definition wll be left empty.",
-                            err.what());
+    RCUTILS_LOG_ERROR_NAMED(
+      "rosbag2_storage_mcap",
+      "Message type name '%s' is not understood by type definition search, "
+      "definition wll be left empty.",
+      err.what());
     format = Format::UNKNOWN;
   } catch (const std::runtime_error & err) {
-    RCUTILS_LOG_ERROR_NAMED("rosbag2_storage_mcap",
-                            "Unexpected error occurred finding message definition, "
-                            "will be left empty: %s",
-                            err.what());
+    RCUTILS_LOG_ERROR_NAMED(
+      "rosbag2_storage_mcap",
+      "Unexpected error occurred finding message definition, "
+      "will be left empty: %s",
+      err.what());
     format = Format::UNKNOWN;
   }
   return std::make_pair(format, result);


### PR DESCRIPTION
@KYabuuchi 
Cursor provided a cache dependencies method that minimize the code interface changes.

I think this update chould be relatively easier to be accepted in the upstream.