### PR TITLE
feat: fast bag split rollover for Jazzy

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/cache/cache_consumer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/cache_consumer.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 
 #include "rosbag2_cpp/cache/cache_consumer.hpp"
@@ -38,16 +39,29 @@ CacheConsumer::~CacheConsumer()
 
 void CacheConsumer::stop()
 {
+  using clock = std::chrono::steady_clock;
+  const auto stop_start = clock::now();
+
   message_cache_->begin_flushing();
   is_stop_issued_ = true;
 
   ROSBAG2_CPP_LOG_INFO_STREAM(
     "Writing remaining messages from cache to the bag. It may take a while");
 
+  double consumer_join_ms = 0.0;
   if (consumer_thread_.joinable()) {
+    const auto join_start = clock::now();
     consumer_thread_.join();
+    consumer_join_ms = std::chrono::duration<double, std::milli>(
+      clock::now() - join_start).count();
   }
   message_cache_->done_flushing();
+
+  const auto total_ms = std::chrono::duration<double, std::milli>(
+    clock::now() - stop_start).count();
+  ROSBAG2_CPP_LOG_INFO_STREAM(
+    "Cache consumer stop timing (ms): total=" << total_ms
+                                              << ", consumer_join=" << consumer_join_ms);
 }
 
 void CacheConsumer::start()

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -319,20 +319,39 @@ std::string SequentialWriter::format_storage_uri(
 
 void SequentialWriter::switch_to_next_storage()
 {
+  using clock = std::chrono::steady_clock;
+  const auto switch_start = clock::now();
+  auto to_ms = [](const auto & duration) {
+      return std::chrono::duration<double, std::milli>(duration).count();
+    };
+
+  double cache_flush_ms = 0.0;
+  double open_new_storage_ms = 0.0;
+  double close_old_storage_ms = 0.0;
+  double reregister_topics_ms = 0.0;
+  double cache_restart_ms = 0.0;
+
   // consume remaining message cache
   if (use_cache_) {
+    const auto cache_flush_start = clock::now();
     cache_consumer_->stop();
     message_cache_->log_dropped();
+    cache_flush_ms = to_ms(clock::now() - cache_flush_start);
   }
 
   storage_->update_metadata(metadata_);
   storage_options_.uri = format_storage_uri(
     base_folder_,
     metadata_.relative_file_paths.size());
+
+  auto previous_storage = std::move(storage_);
+  const auto open_new_storage_start = clock::now();
   // TODO(morlov): If we would ever remove the upper level writer mutex lock, consider protecting
   //  storage_ with mutex to avoid race conditions with write(msg) call when we are switching to
   //  next storage and not using cache.
   storage_ = storage_factory_->open_read_write(storage_options_);
+  open_new_storage_ms = to_ms(clock::now() - open_new_storage_start);
+
   if (!storage_) {
     std::stringstream errmsg;
     errmsg << "Failed to rollover bagfile to new file: \"" << storage_options_.uri << "\"!";
@@ -348,19 +367,40 @@ void SequentialWriter::switch_to_next_storage()
   metadata_.relative_file_paths.push_back(file_info.path);
 
   storage_->update_metadata(metadata_);
+
+  const auto close_old_storage_start = clock::now();
+  previous_storage.reset();
+  close_old_storage_ms = to_ms(clock::now() - close_old_storage_start);
+
   {
     // Re-register all topics since we rolled-over to a new bagfile.
+    const auto reregister_topics_start = clock::now();
     std::lock_guard<std::mutex> lock(topics_info_mutex_);
     for (const auto & topic : topics_names_to_info_) {
       auto const & md = topic_names_to_message_definitions_[topic.first];
       storage_->create_topic(topic.second.topic_metadata, md);
     }
+    reregister_topics_ms = to_ms(clock::now() - reregister_topics_start);
   }
 
   if (use_cache_) {
+    const auto cache_restart_start = clock::now();
     // restart consumer thread for cache
     cache_consumer_->start();
+    cache_restart_ms = to_ms(clock::now() - cache_restart_start);
   }
+
+  const auto total_ms = to_ms(clock::now() - switch_start);
+  ROSBAG2_CPP_LOG_INFO_STREAM(
+    "Bag split storage switch timing (ms): "
+    << "total=" << total_ms
+    << ", cache_flush=" << cache_flush_ms
+    << ", open_new_storage=" << open_new_storage_ms
+    << ", close_old_storage=" << close_old_storage_ms
+    << ", reregister_topics=" << reregister_topics_ms
+    << " (" << topics_names_to_info_.size() << " topics)"
+    << ", cache_restart=" << cache_restart_ms
+    << ", new_file=\"" << storage_options_.uri << "\"");
 }
 
 std::string SequentialWriter::split_bagfile_local(bool execute_callbacks)


### PR DESCRIPTION
## Summary
- Defer closing the previous bag storage until after the new bag file is opened during rollover, reducing blocking time on bag split.
- Add timing instrumentation in `CacheConsumer::stop()` and `SequentialWriter::switch_to_next_storage()` to profile cache flush, storage open/close, topic re-registration, and cache restart phases.

## Notes
- Ported from the Humble fix (`edcb7fd1`) and adapted for Jazzy's writer API (metadata updates, `topics_info_mutex_`, and `create_topic(..., message_definition)`).
- Jazzy-specific `MessageDefinitionCache` changes from the original commit were not needed because message definitions are now passed from the writer layer.

## Test plan
- [ ] Record a bag with `max_bagfile_size` or `max_bagfile_duration` enabled and verify rollover succeeds
- [ ] Confirm timing logs appear for cache consumer stop and bag split storage switch
- [ ] Verify split bags contain all expected topics and message definitions


Made with [Cursor](https://cursor.com)