### PR TITLE
fix(mcap): skip metadata writing and close async IO to speed up spliting

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -280,6 +280,18 @@ void SequentialWriter::switch_to_next_storage()
   storage_options_.uri = format_storage_uri(
     base_folder_,
     metadata_.relative_file_paths.size());
+
+  // Fast path for storage plugins that implement rollover() (e.g. MCAP).
+  // File rotation and schema/channel re-registration are handled by the plugin itself.
+  // Returning here intentionally skips the generic fallback below, which
+  // recreates the storage and re-registers all topics (~200+ ms with hundreds of topics).
+  if (storage_->rollover(storage_options_)) {
+    if (use_cache_) {
+      cache_consumer_->start();
+    }
+    return;
+  }
+
   storage_ = storage_factory_->open_read_write(storage_options_);
 
   if (!storage_) {

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
@@ -20,6 +20,7 @@
 #include "rosbag2_storage/storage_filter.hpp"
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/base_write_interface.hpp"
+#include "rosbag2_storage/storage_options.hpp"
 #include "rosbag2_storage/storage_traits.hpp"
 #include "rosbag2_storage/visibility_control.hpp"
 
@@ -58,6 +59,14 @@ public:
   }
 
   void seek(const rcutils_time_point_value_t & timestamp) override = 0;
+
+  /// \brief Close the current bag file and open a new one, registering cached topics in the new file.
+  /// \return true if rollover succeeded; false if not supported (caller should open a new storage).
+  virtual bool rollover(const StorageOptions & storage_options)
+  {
+    (void)storage_options;
+    return false;
+  }
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -222,9 +222,11 @@ public:
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_UPDATE_METADATA
   void update_metadata(const rosbag2_storage::BagMetadata &) override;
 #endif
+  bool rollover(const rosbag2_storage::StorageOptions & storage_options) override;
 
 private:
   void write_lock_free(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg);
+  void register_cached_topics();
   void open_impl(const std::string & uri, const std::string & preset_profile,
                  rosbag2_storage::storage_interfaces::IOFlag io_flag,
                  const std::string & storage_config_uri);
@@ -261,6 +263,13 @@ private:
 
   std::unique_ptr<mcap::McapWriter> mcap_writer_;
   rosbag2_storage_mcap::internal::MessageDefinitionCache msgdef_cache_{};
+
+  McapWriterOptions writer_options_;
+  bool writer_options_initialized_{false};
+  std::unordered_map<std::string, mcap::Schema> cached_mcap_schemas_
+    RCPPUTILS_TSA_GUARDED_BY(mcap_storage_mutex_);
+  std::unordered_map<std::string, mcap::Channel> cached_mcap_channels_
+    RCPPUTILS_TSA_GUARDED_BY(mcap_storage_mutex_);
 
   bool has_read_summary_ = false;
   bool has_added_ros_distro_metadata_ = false;
@@ -368,6 +377,8 @@ void MCAPStorage::open_impl(const std::string & uri, const std::string & preset_
       if (!status.ok()) {
         throw std::runtime_error(status.message);
       }
+      writer_options_ = options;
+      writer_options_initialized_ = true;
       ensure_rosdistro_metadata_added();
       break;
     }
@@ -763,6 +774,7 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
                               datatype.c_str(), err.what());
       schema.encoding = "";
     }
+    cached_mcap_schemas_[datatype] = schema;
     mcap_writer_->addSchema(schema);
     schema_ids_.emplace(datatype, schema.id);
     schema_id = schema.id;
@@ -779,6 +791,7 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
     channel.schemaId = schema_id;
     channel.metadata.emplace("offered_qos_profiles",
                              topic_info.topic_metadata.offered_qos_profiles);
+    cached_mcap_channels_[topic.name] = channel;
     mcap_writer_->addChannel(channel);
     channel_ids_.emplace(topic.name, channel.id);
   }
@@ -792,7 +805,70 @@ void MCAPStorage::remove_topic(const rosbag2_storage::TopicMetadata & topic)
     const auto & datatype = topic_it->second.topic_metadata.type;
     schema_ids_.erase(datatype);
     topics_.erase(topic.name);
+    channel_ids_.erase(topic.name);
+    cached_mcap_channels_.erase(topic.name);
+    const bool datatype_still_used = std::any_of(
+      topics_.begin(), topics_.end(),
+      [&datatype](const auto & entry) {
+        return entry.second.topic_metadata.type == datatype;
+      });
+    if (!datatype_still_used) {
+      cached_mcap_schemas_.erase(datatype);
+    }
   }
+}
+
+void MCAPStorage::register_cached_topics()
+{
+  schema_ids_.clear();
+  channel_ids_.clear();
+
+  for (const auto & [datatype, schema_template] : cached_mcap_schemas_) {
+    mcap::Schema schema = schema_template;
+    mcap_writer_->addSchema(schema);
+    schema_ids_.emplace(datatype, schema.id);
+  }
+
+  for (const auto & [topic_name, channel_template] : cached_mcap_channels_) {
+    const auto topic_it = topics_.find(topic_name);
+    if (topic_it == topics_.end()) {
+      continue;
+    }
+    mcap::Channel channel = channel_template;
+    const auto & datatype = topic_it->second.topic_metadata.type;
+    channel.schemaId = schema_ids_.at(datatype);
+    mcap_writer_->addChannel(channel);
+    channel_ids_.emplace(topic_name, channel.id);
+  }
+}
+
+bool MCAPStorage::rollover(const rosbag2_storage::StorageOptions & storage_options)
+{
+  if (!mcap_writer_ || !writer_options_initialized_ || cached_mcap_channels_.empty()) {
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
+  mcap_writer_->close();
+
+  relative_path_ = storage_options.uri + FILE_EXTENSION;
+  mcap_writer_ = std::make_unique<mcap::McapWriter>();
+  auto status = mcap_writer_->open(relative_path_, writer_options_);
+  if (!status.ok()) {
+    throw std::runtime_error(status.message);
+  }
+
+  for (auto & [topic_name, topic_info] : topics_) {
+    (void)topic_name;
+    topic_info.message_count = 0;
+  }
+  metadata_.message_count = 0;
+  metadata_.duration = std::chrono::nanoseconds(0);
+  metadata_.starting_time = time_point(std::chrono::nanoseconds::max());
+  metadata_.relative_file_paths = {get_relative_file_path()};
+
+  register_cached_topics();
+  return true;
 }
 
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_UPDATE_METADATA

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -46,11 +46,15 @@
 #include <mcap/mcap.hpp>
 
 #include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
 #include <filesystem>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -165,6 +169,100 @@ static void OnProblem(const mcap::Status & status)
   RCUTILS_LOG_ERROR_NAMED(LOG_NAME, "%s", status.message.c_str());
 }
 
+namespace
+{
+
+/// Closes MCAP writers on a background thread so rollover can open the next file without
+/// blocking on summary/footer I/O for the previous file.
+class McapWriterAsyncCloser
+{
+public:
+  McapWriterAsyncCloser()
+  {
+    worker_ = std::thread([this]() {  worker_loop(); });
+  }
+
+  ~McapWriterAsyncCloser() { shutdown(); }
+
+  McapWriterAsyncCloser(const McapWriterAsyncCloser &) = delete;
+  McapWriterAsyncCloser & operator=(const McapWriterAsyncCloser &) = delete;
+
+  void enqueue(std::unique_ptr<mcap::McapWriter> writer, std::string relative_path)
+  {
+    if (!writer) {
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      queue_.push_back({std::move(writer), std::move(relative_path)});
+    }
+    cv_.notify_one();
+  }
+
+  void shutdown()
+  {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (shutdown_) {
+        return;
+      }
+      shutdown_ = true;
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) {
+      worker_.join();
+    }
+  }
+
+private:
+  struct CloseJob
+  {
+    std::unique_ptr<mcap::McapWriter> writer;
+    std::string relative_path;
+  };
+
+  void worker_loop()
+  {
+    while (true) {
+      CloseJob job;
+      {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this]() { return shutdown_ || !queue_.empty(); });
+        if (shutdown_ && queue_.empty()) {
+          return;
+        }
+        job = std::move(queue_.front());
+        queue_.pop_front();
+      }
+
+      if (job.writer) {
+        const auto close_start = std::chrono::steady_clock::now();
+        try {
+          job.writer->close();
+        } catch (const std::exception & e) {
+          RCUTILS_LOG_ERROR_NAMED(
+            LOG_NAME, "Async MCAP close failed for \"%s\": %s", job.relative_path.c_str(),
+            e.what());
+        }
+        const double close_ms =
+          std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - close_start)
+            .count();
+        RCUTILS_LOG_INFO_NAMED(
+          LOG_NAME, "MCAP async close timing (ms): close=%.3f, file=\"%s\"", close_ms,
+          job.relative_path.c_str());
+      }
+    }
+  }
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::deque<CloseJob> queue_;
+  std::thread worker_;
+  bool shutdown_{false};
+};
+
+}  // namespace
+
 /**
  * A storage implementation for the MCAP file format.
  */
@@ -271,6 +369,8 @@ private:
   std::unordered_map<std::string, mcap::Channel> cached_mcap_channels_
     RCPPUTILS_TSA_GUARDED_BY(mcap_storage_mutex_);
 
+  std::unique_ptr<McapWriterAsyncCloser> async_writer_closer_;
+
   bool has_read_summary_ = false;
   bool has_added_ros_distro_metadata_ = false;
   rcutils_time_point_value_t last_read_time_point_ = 0;
@@ -291,6 +391,11 @@ MCAPStorage::~MCAPStorage()
   }
   if (input_) {
     input_->close();
+  }
+  // Wait for any rollover-triggered async closes before closing the active writer.
+  if (async_writer_closer_) {
+    async_writer_closer_->shutdown();
+    async_writer_closer_.reset();
   }
   if (mcap_writer_) {
     mcap_writer_->close();
@@ -379,6 +484,9 @@ void MCAPStorage::open_impl(const std::string & uri, const std::string & preset_
       }
       writer_options_ = options;
       writer_options_initialized_ = true;
+      if (!async_writer_closer_) {
+        async_writer_closer_ = std::make_unique<McapWriterAsyncCloser>();
+      }
       ensure_rosdistro_metadata_added();
       break;
     }
@@ -820,15 +928,25 @@ void MCAPStorage::remove_topic(const rosbag2_storage::TopicMetadata & topic)
 
 void MCAPStorage::register_cached_topics()
 {
+  using clock = std::chrono::steady_clock;
+  const auto register_start = clock::now();
+  auto to_ms = [](const auto & duration) {
+    return std::chrono::duration<double, std::milli>(duration).count();
+  };
+
   schema_ids_.clear();
   channel_ids_.clear();
 
+  const auto add_schemas_start = clock::now();
   for (const auto & [datatype, schema_template] : cached_mcap_schemas_) {
     mcap::Schema schema = schema_template;
     mcap_writer_->addSchema(schema);
     schema_ids_.emplace(datatype, schema.id);
   }
+  const double add_schemas_ms = to_ms(clock::now() - add_schemas_start);
 
+  const auto add_channels_start = clock::now();
+  size_t channels_registered = 0;
   for (const auto & [topic_name, channel_template] : cached_mcap_channels_) {
     const auto topic_it = topics_.find(topic_name);
     if (topic_it == topics_.end()) {
@@ -839,7 +957,16 @@ void MCAPStorage::register_cached_topics()
     channel.schemaId = schema_ids_.at(datatype);
     mcap_writer_->addChannel(channel);
     channel_ids_.emplace(topic_name, channel.id);
+    ++channels_registered;
   }
+  const double add_channels_ms = to_ms(clock::now() - add_channels_start);
+
+  RCUTILS_LOG_INFO_NAMED(
+    LOG_NAME,
+    "MCAP register_cached_topics timing (ms): total=%.3f, add_schemas=%.3f (%zu schemas), "
+    "add_channels=%.3f (%zu channels)",
+    to_ms(clock::now() - register_start), add_schemas_ms, cached_mcap_schemas_.size(),
+    add_channels_ms, channels_registered);
 }
 
 bool MCAPStorage::rollover(const rosbag2_storage::StorageOptions & storage_options)
@@ -848,26 +975,63 @@ bool MCAPStorage::rollover(const rosbag2_storage::StorageOptions & storage_optio
     return false;
   }
 
-  std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
-  mcap_writer_->close();
+  using clock = std::chrono::steady_clock;
+  const auto rollover_start = clock::now();
+  auto to_ms = [](const auto & duration) {
+    return std::chrono::duration<double, std::milli>(duration).count();
+  };
 
-  relative_path_ = storage_options.uri + FILE_EXTENSION;
-  mcap_writer_ = std::make_unique<mcap::McapWriter>();
-  auto status = mcap_writer_->open(relative_path_, writer_options_);
-  if (!status.ok()) {
-    throw std::runtime_error(status.message);
+  std::unique_ptr<mcap::McapWriter> old_writer;
+  std::string closing_relative_path;
+
+  {
+    std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
+
+    old_writer = std::move(mcap_writer_);
+    closing_relative_path = relative_path_;
+
+    relative_path_ = storage_options.uri + FILE_EXTENSION;
+
+    const auto open_start = clock::now();
+    mcap_writer_ = std::make_unique<mcap::McapWriter>();
+    auto status = mcap_writer_->open(relative_path_, writer_options_);
+    const double open_ms = to_ms(clock::now() - open_start);
+    if (!status.ok()) {
+      mcap_writer_.reset();
+      mcap_writer_ = std::move(old_writer);
+      relative_path_ = closing_relative_path;
+      throw std::runtime_error(status.message);
+    }
+
+    const auto reset_metadata_start = clock::now();
+    for (auto & [topic_name, topic_info] : topics_) {
+      (void)topic_name;
+      topic_info.message_count = 0;
+    }
+    metadata_.message_count = 0;
+    metadata_.duration = std::chrono::nanoseconds(0);
+    metadata_.starting_time = time_point(std::chrono::nanoseconds::max());
+    metadata_.relative_file_paths = {get_relative_file_path()};
+    const double reset_metadata_ms = to_ms(clock::now() - reset_metadata_start);
+
+    const auto register_topics_start = clock::now();
+    register_cached_topics();
+    const double register_topics_ms = to_ms(clock::now() - register_topics_start);
+
+    const double sync_rollover_ms = to_ms(clock::now() - rollover_start);
+    RCUTILS_LOG_INFO_NAMED(
+      LOG_NAME,
+      "MCAP rollover timing (ms): sync_total=%.3f, close=async_scheduled, open=%.3f, "
+      "reset_metadata=%.3f, register_cached_topics=%.3f, closing_file=\"%s\", new_file=\"%s\"",
+      sync_rollover_ms, open_ms, reset_metadata_ms, register_topics_ms,
+      closing_relative_path.c_str(), relative_path_.c_str());
   }
 
-  for (auto & [topic_name, topic_info] : topics_) {
-    (void)topic_name;
-    topic_info.message_count = 0;
+  if (!async_writer_closer_) {
+    async_writer_closer_ = std::make_unique<McapWriterAsyncCloser>();
   }
-  metadata_.message_count = 0;
-  metadata_.duration = std::chrono::nanoseconds(0);
-  metadata_.starting_time = time_point(std::chrono::nanoseconds::max());
-  metadata_.relative_file_paths = {get_relative_file_path()};
+  async_writer_closer_->enqueue(std::move(old_writer), std::move(closing_relative_path));
 
-  register_cached_topics();
   return true;
 }
 


### PR DESCRIPTION
## Description

[TIER IV internal discussion](https://star4.slack.com/archives/C03QU7K50D8/p1781227717323979)
[TIER IV internal ticket](https://tier4.atlassian.net/browse/T4DEV-54397)

- related PR to tier4/jazzy : https://github.com/tier4/rosbag2/pull/19

> [!NOTE]
> Non-MCAP (sqlite3) storage plugins are unchanged.


### Problem

When recording MCAP bags with file splitting enabled (`-d 60`), each split blocks the recorder callback for a noticeable amount of time. With hundreds of topics, a single split can take **~300+ ms**, which can cause message drops under high load.

Two main bottlenecks were identified:

1. **`update_metadata()` on every split** — `SequentialWriter::switch_to_next_storage()` called `storage_->update_metadata(metadata_)` twice per split. For MCAP, this serializes the full session `BagMetadata` (all topics and all split file paths) to YAML and embeds it in the closing bag file. Cost grows with topic count and number of prior splits.

2. **Generic storage recreation** — The fallback path destroys and reopens the storage plugin, then re-registers every topic from scratch (~200+ ms with hundreds of topics).

### Solution

This PR reduces split latency through three complementary changes:

1. **Skip `update_metadata()` during split** — Metadata is still written when the recording session ends (`flush_cache_update_metadata_and_close_storage()` and `close()`), so skipping it at split time does not lose final bag metadata.

2. **Add `rollover()` to the storage interface** — `ReadWriteInterface` gains an optional `rollover(StorageOptions)` hook (default: `false`). Storage plugins that support in-place file rotation can implement it and avoid full storage recreation.

3. **MCAP fast-path rollover** — `MCAPStorage::rollover()`:
   - Caches MCAP schema/channel definitions at `create_topic()` time
   - On split: opens the next file synchronously and re-registers topics from cache via `register_cached_topics()`
   - Closes the previous `McapWriter` **asynchronously** on a background thread (`McapWriterAsyncCloser`), so summary/footer I/O does not block the recorder

> [!NOTE]
> Non-MCAP (sqlite3) storage plugins are unchanged.

### Expected impact

- Split callback time for MCAP should drop from **~300+ ms** to roughly **tens of ms** (dominated by opening the new file and re-registering cached schemas/channels), with MCAP close I/O moved off the hot path.
- Timing logs are emitted at `INFO` level for rollover and async close, to aid validation in real workloads.

## How was this PR tested

- [x] Recorded rosbags at **~7 GB/minute** with the `zstd_fast` compression option for several minutes and confirmed no noticeable topic drops.
- [x] Loaded the recorded MCAP files into Lichtblick and verified visualization works.
- [x] Recorded topics from [Autoware (planning_simulator.launch.xml)](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#create-your-own-map) with the command below and confirmed that split latency dropped from 300 ms to 10 ms.

```bash
ros2 bag record -s mcap -a -d 10
```

| before mcap | after mcap|
| -----| ---|
|   <img width="1420" height="494" alt="image" src="https://github.com/user-attachments/assets/3df95bef-4baf-4287-9264-b5b86eabe76d" /> |  <img width="1420" height="494" alt="image" src="https://github.com/user-attachments/assets/6e6c42ec-84ff-43d3-9f49-e8e9590b8684" /> |

```bash
ros2 bag record -s sqlite3 -a -d 10
```

| before sqlite3 | after sqlite3 |
| -----| ---|
| <img width="1420" height="494" alt="image" src="https://github.com/user-attachments/assets/6f5dfef9-d29d-4bbb-abad-f1bb75e39747" /> | <img width="1420" height="494" alt="image" src="https://github.com/user-attachments/assets/1c072933-5325-4694-ae9a-e0f7b5756a2a" />|


[plot_rosbag_header_stamp.py](https://github.com/user-attachments/files/29375326/plot_rosbag_header_stamp.py)
