### PR TITLE
fix: colcon test failures introduced by the MCAP split-optimization commit

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -366,7 +366,10 @@ TEST_F(SequentialCompressionWriterTest, writer_call_metadata_update_on_bag_split
   initializeFakeFileStorage();
   initializeWriter(compression_options);
 
-  EXPECT_CALL(*storage_, update_metadata(_)).Times(4);
+  // update_metadata() is no longer called during switch_to_next_storage() (skipped for
+  // performance, see SequentialWriter::switch_to_next_storage()), so a split no longer triggers
+  // metadata updates. It is only called on opening the first bag file and on writer destruction.
+  EXPECT_CALL(*storage_, update_metadata(_)).Times(2);
   writer_->open(tmp_dir_storage_options_);
   writer_->create_topic({0u, test_topic_name, test_topic_type, "", {}, ""});
 
@@ -385,16 +388,14 @@ TEST_F(SequentialCompressionWriterTest, writer_call_metadata_update_on_bag_split
   }
   writer_.reset();  // reset will call writer destructor
 
-  ASSERT_EQ(v_intercepted_update_metadata_.size(), 4u);
+  ASSERT_EQ(v_intercepted_update_metadata_.size(), 2u);
   using rosbag2_compression::compression_mode_from_string;
   auto compression_mode =
     compression_mode_from_string(v_intercepted_update_metadata_[0].compression_mode);
   EXPECT_EQ(compression_mode, rosbag2_compression::CompressionMode::MESSAGE);
   EXPECT_EQ(v_intercepted_update_metadata_[0].message_count, 0u);  // On opening first bag file
-  EXPECT_EQ(v_intercepted_update_metadata_[1].files.size(), 1u);   // On closing first bag file
-  EXPECT_EQ(v_intercepted_update_metadata_[2].files.size(), 2u);   // On opening second bag file
-  EXPECT_EQ(v_intercepted_update_metadata_[3].files.size(), 2u);   // On writer destruction
-  EXPECT_EQ(v_intercepted_update_metadata_[3].message_count, 2 * kNumMessagesToWrite);
+  EXPECT_EQ(v_intercepted_update_metadata_[1].files.size(), 2u);   // On writer destruction
+  EXPECT_EQ(v_intercepted_update_metadata_[1].message_count, 2 * kNumMessagesToWrite);
 }
 
 TEST_P(SequentialCompressionWriterTest, writer_writes_with_compression_queue_sizes)

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -239,7 +239,10 @@ TEST_F(SequentialWriterTest, sequantial_writer_call_metadata_update_on_bag_split
 {
   const std::string test_topic_name = "test_topic";
   const std::string test_topic_type = "test_msgs/BasicTypes";
-  EXPECT_CALL(*storage_, update_metadata(_)).Times(4);
+  // update_metadata() is no longer called during switch_to_next_storage() (skipped for
+  // performance, see SequentialWriter::switch_to_next_storage()), so a split no longer triggers
+  // metadata updates. It is only called on opening the first bag file and on writer destruction.
+  EXPECT_CALL(*storage_, update_metadata(_)).Times(2);
 
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
@@ -264,13 +267,11 @@ TEST_F(SequentialWriterTest, sequantial_writer_call_metadata_update_on_bag_split
   }
   writer_.reset();  // reset will call writer destructor
 
-  ASSERT_EQ(v_intercepted_update_metadata_.size(), 4u);
+  ASSERT_EQ(v_intercepted_update_metadata_.size(), 2u);
   EXPECT_TRUE(v_intercepted_update_metadata_[0].compression_mode.empty());
   EXPECT_EQ(v_intercepted_update_metadata_[0].message_count, 0u);  // On opening first bag file
-  EXPECT_EQ(v_intercepted_update_metadata_[1].files.size(), 1u);   // On closing first bag file
-  EXPECT_EQ(v_intercepted_update_metadata_[2].files.size(), 2u);   // On opening second bag file
-  EXPECT_EQ(v_intercepted_update_metadata_[3].files.size(), 2u);   // On writer destruction
-  EXPECT_EQ(v_intercepted_update_metadata_[3].message_count, 2 * kNumMessagesToWrite);
+  EXPECT_EQ(v_intercepted_update_metadata_[1].files.size(), 2u);   // On writer destruction
+  EXPECT_EQ(v_intercepted_update_metadata_[1].message_count, 2 * kNumMessagesToWrite);
 }
 
 TEST_F(SequentialWriterTest, open_throws_error_if_converter_plugin_does_not_exist) {
@@ -719,23 +720,27 @@ TEST_F(SequentialWriterTest, snapshot_writes_to_new_file_with_bag_split)
   ASSERT_STREQ(closed_files[0].c_str(), expected_closed.generic_string().c_str());
   ASSERT_STREQ(opened_files[0].c_str(), expected_opened.generic_string().c_str());
 
+  // Reset the writer to finalize and flush the metadata. update_metadata() is no longer called
+  // during switch_to_next_storage() (skipped for performance, see
+  // SequentialWriter::switch_to_next_storage()), so the snapshot file information is reported in
+  // the final update_metadata() call on writer close instead of during the split.
+  writer_.reset();
+
   // Check metadata
-  ASSERT_EQ(v_intercepted_update_metadata_.size(), 3u);
-  // The v_intercepted_update_metadata_[0] is the very first metadata saved from the writer's
-  // constructor. We don't update it during the snapshot, and it doesn't make sense checking it.
-  // The v_intercepted_update_metadata_[1] is the metadata written right before closing the file
-  // with the new snapshot.
-  // The v_intercepted_update_metadata_[2] is the metadata written when we are opening a new file
-  // after switching to a new storage.
-  EXPECT_EQ(v_intercepted_update_metadata_[1].message_count, num_expected_msgs);
-  EXPECT_EQ(v_intercepted_update_metadata_[2].message_count, num_expected_msgs);
+  ASSERT_EQ(v_intercepted_update_metadata_.size(), 2u);
+  // The v_intercepted_update_metadata_[0] is the very first metadata saved when the first bag file
+  // is opened. We don't update it during the snapshot, and it doesn't make sense checking it.
+  // The v_intercepted_update_metadata_[1] is the final metadata written on writer close, which
+  // contains the snapshot file information.
+  const auto & final_metadata = v_intercepted_update_metadata_[1];
+  EXPECT_EQ(final_metadata.message_count, num_expected_msgs);
   EXPECT_EQ(
     std::chrono::time_point_cast<std::chrono::nanoseconds>(
-      v_intercepted_update_metadata_[1].starting_time).time_since_epoch().count(),
+      final_metadata.starting_time).time_since_epoch().count(),
     first_msg_timestamp);
 
-  ASSERT_FALSE(v_intercepted_update_metadata_[1].files.empty());
-  const auto & first_file_info = v_intercepted_update_metadata_[1].files[0];
+  ASSERT_FALSE(final_metadata.files.empty());
+  const auto & first_file_info = final_metadata.files[0];
   EXPECT_STREQ(first_file_info.path.c_str(), std::string(bag_base_dir_ + "_0").c_str());
   EXPECT_EQ(first_file_info.message_count, num_expected_msgs);
   EXPECT_EQ(

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
@@ -60,7 +60,8 @@ public:
 
   void seek(const rcutils_time_point_value_t & timestamp) override = 0;
 
-  /// \brief Close the current bag file and open a new one, registering cached topics in the new file.
+  /// \brief Close the current bag file and open a new one, registering cached topics in the
+  /// new file.
   /// \return true if rollover succeeded; false if not supported (caller should open a new storage).
   virtual bool rollover(const StorageOptions & storage_options)
   {

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -41,9 +41,9 @@
 #include <mcap/mcap.hpp>
 
 #include <algorithm>
-#include <cstring>
 #include <chrono>
 #include <condition_variable>
+#include <cstring>
 #include <deque>
 #include <filesystem>
 #include <memory>
@@ -181,10 +181,15 @@ class McapWriterAsyncCloser
 public:
   McapWriterAsyncCloser()
   {
-    worker_ = std::thread([this]() {  worker_loop(); });
+    worker_ = std::thread([this]() {
+      worker_loop();
+    });
   }
 
-  ~McapWriterAsyncCloser() { shutdown(); }
+  ~McapWriterAsyncCloser()
+  {
+    shutdown();
+  }
 
   McapWriterAsyncCloser(const McapWriterAsyncCloser &) = delete;
   McapWriterAsyncCloser & operator=(const McapWriterAsyncCloser &) = delete;
@@ -229,7 +234,9 @@ private:
       CloseJob job;
       {
         std::unique_lock<std::mutex> lock(mutex_);
-        cv_.wait(lock, [this]() { return shutdown_ || !queue_.empty(); });
+        cv_.wait(lock, [this]() {
+          return shutdown_ || !queue_.empty();
+        });
         if (shutdown_ && queue_.empty()) {
           return;
         }
@@ -242,16 +249,14 @@ private:
         try {
           job.writer->close();
         } catch (const std::exception & e) {
-          RCUTILS_LOG_ERROR_NAMED(
-            LOG_NAME, "Async MCAP close failed for \"%s\": %s", job.relative_path.c_str(),
-            e.what());
+          RCUTILS_LOG_ERROR_NAMED(LOG_NAME, "Async MCAP close failed for \"%s\": %s",
+                                  job.relative_path.c_str(), e.what());
         }
         const double close_ms =
           std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - close_start)
             .count();
-        RCUTILS_LOG_INFO_NAMED(
-          LOG_NAME, "MCAP async close timing (ms): close=%.3f, file=\"%s\"", close_ms,
-          job.relative_path.c_str());
+        RCUTILS_LOG_INFO_NAMED(LOG_NAME, "MCAP async close timing (ms): close=%.3f, file=\"%s\"",
+                               close_ms, job.relative_path.c_str());
       }
     }
   }
@@ -1071,9 +1076,8 @@ void MCAPStorage::remove_topic(const rosbag2_storage::TopicMetadata & topic)
     topics_.erase(topic.name);
     channel_ids_.erase(topic.name);
     cached_mcap_channels_.erase(topic.name);
-    const bool datatype_still_used = std::any_of(
-      topics_.begin(), topics_.end(),
-      [&datatype](const auto & entry) {
+    const bool datatype_still_used =
+      std::any_of(topics_.begin(), topics_.end(), [&datatype](const auto & entry) {
         return entry.second.topic_metadata.type == datatype;
       });
     if (!datatype_still_used) {


### PR DESCRIPTION
### Summary

Commit 2724a3a7 (*"fix(mcap): skip metadata writing and close async IO to speed up splitting (#19)"*) changed writer/storage behavior and added new code, but did not update the affected tests or run the linters. This left `colcon test` red across 4 packages. This PR updates the tests and formatting to match the new intended behavior. **No production logic is changed** — only tests, comments, and formatting.

### Failures fixed

| Package | Test | Kind |
|---|---|---|
| `rosbag2_cpp` | `sequantial_writer_call_metadata_update_on_bag_split` | gtest assertion |
| `rosbag2_cpp` | `snapshot_writes_to_new_file_with_bag_split` | gtest assertion |
| `rosbag2_compression` | `writer_call_metadata_update_on_bag_split` | gtest assertion |
| `rosbag2_storage` | `cpplint` (`read_write_interface.hpp:63`) | lint |
| `rosbag2_storage_mcap` | `clang_format` (`mcap_storage.cpp`, 17 divergences) | format |

### Root cause

`2724a3a7` removed the two `storage_->update_metadata()` calls inside `SequentialWriter::switch_to_next_storage()` (they serialized the full session metadata into the closing bag on every split — a ~100+ ms stall with many topics). As a result, a bag split no longer triggers per-split metadata updates; metadata is now finalized only on writer close. The existing tests still asserted the old call counts (`4` on split, `3` on snapshot), so they failed with the new counts (`2` and `1`).

### Changes

**`fix: failed tests due to metadata updates` (`88529c39`)**

- `test_sequential_writer.cpp` — `..._call_metadata_update_on_bag_split`: expect `2` `update_metadata` calls (open + destruction) instead of `4`, and validate the final aggregated metadata.
- `test_sequential_writer.cpp` — `snapshot_writes_to_new_file_with_bag_split`: reset the writer to flush the final metadata, then assert the snapshot file's message count / start time / duration there, since that information is now reported on close rather than mid-split.
- `test_sequential_compression_writer.cpp` — `writer_call_metadata_update_on_bag_split`: same `4 → 2` adjustment.

**`fix: formatting error` (`be1fd8f6`)**

- `read_write_interface.hpp` — wrapped the new `rollover()` doc comment to satisfy cpplint (≤100 chars).
- `mcap_storage.cpp` — reformatted **only the newly-added code** via `ament_clang_format --config .clang-format` (17 divergences). Using the package's own config keeps this to a minimal 30-line diff instead of rewriting pre-existing code.

### Testing
`colcon test --packages-select rosbag2_cpp rosbag2_compression rosbag2_storage rosbag2_storage_mcap`


